### PR TITLE
Confirmation box

### DIFF
--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@nextui-org/react";
-import { Dispatch, SetStateAction } from "react";
 
 interface OkOptions {
   penalty: number;
@@ -8,11 +7,11 @@ interface OkOptions {
 interface ConfirmProps {
   active: boolean;
   ok: (arg0?: OkOptions) => Promise<void>;
-  setActive: Dispatch<SetStateAction<boolean>>;
+  toggle: () => void;
 }
 
 const Confirm = (props: ConfirmProps) => {
-  const { active, ok, setActive } = props;
+  const { active, ok, toggle } = props;
 
   if (!active) return <></>;
 
@@ -32,10 +31,7 @@ const Confirm = (props: ConfirmProps) => {
               color: "black",
               borderRadius: "4px",
             }}
-            onClick={() => {
-              ok();
-              setActive(false);
-            }}
+            onClick={() => ok()}
           >
             Confirm
           </Button>
@@ -48,7 +44,6 @@ const Confirm = (props: ConfirmProps) => {
             }}
             onClick={() => {
               ok({ penalty: 2000 });
-              setActive(false);
             }}
           >
             +2
@@ -60,7 +55,7 @@ const Confirm = (props: ConfirmProps) => {
               color: "black",
               borderRadius: "4px",
             }}
-            onClick={() => setActive(false)}
+            onClick={toggle}
           >
             Reject
           </Button>

--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -1,19 +1,70 @@
+import { Button } from "@nextui-org/react";
+import { Dispatch, SetStateAction } from "react";
+
+interface OkOptions {
+  penalty: number;
+}
+
 interface ConfirmProps {
   active: boolean;
-  callback: () => Promise<void>;
+  ok: (arg0?: OkOptions) => Promise<void>;
+  setActive: Dispatch<SetStateAction<boolean>>;
 }
 
 const Confirm = (props: ConfirmProps) => {
-  const { active, callback } = props;
+  const { active, ok, setActive } = props;
+
+  if (!active) return <></>;
 
   return (
     <div
-      className={`fixed inset-0 z-50 overflow-auto bg-smoke-light flex ${
+      className={`fixed left-200 inset-28 top-30 z-50 overflow-auto bg-smoke-light flex ${
         active ? "" : "hidden"
       }`}
     >
-      <div className="relative p-8 bg-white w-full max-w-md m-auto flex-col flex rounded-lg">
-        <button onClick={callback}>Confirm?</button>
+      <div className="relative p-8 bg-white max-w-md m-auto border-2 border-zinc-900 flex-col flex rounded-lg">
+        <p className="pb-6">Would you like to save this time?</p>
+        <div className="flex gap-x-4">
+          <Button
+            auto
+            css={{
+              background: "#22c55e",
+              color: "black",
+              borderRadius: "4px",
+            }}
+            onClick={() => {
+              ok();
+              setActive(false);
+            }}
+          >
+            Confirm
+          </Button>
+          <Button
+            auto
+            css={{
+              color: "black",
+              background: "#fb923c",
+              borderRadius: "4px",
+            }}
+            onClick={() => {
+              ok({ penalty: 2000 });
+              setActive(false);
+            }}
+          >
+            +2
+          </Button>
+          <Button
+            auto
+            css={{
+              background: "#ef4444",
+              color: "black",
+              borderRadius: "4px",
+            }}
+            onClick={() => setActive(false)}
+          >
+            Reject
+          </Button>
+        </div>
         <span className="absolute top-0 right-0 p-4"></span>
       </div>
     </div>
@@ -21,3 +72,5 @@ const Confirm = (props: ConfirmProps) => {
 };
 
 export default Confirm;
+
+/*background: "rgb(250 202 21 / var(--tw-bg-opacity))",*/

--- a/src/components/Confirm/Confirm.tsx
+++ b/src/components/Confirm/Confirm.tsx
@@ -1,0 +1,23 @@
+interface ConfirmProps {
+  active: boolean;
+  callback: () => Promise<void>;
+}
+
+const Confirm = (props: ConfirmProps) => {
+  const { active, callback } = props;
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 overflow-auto bg-smoke-light flex ${
+        active ? "" : "hidden"
+      }`}
+    >
+      <div className="relative p-8 bg-white w-full max-w-md m-auto flex-col flex rounded-lg">
+        <button onClick={callback}>Confirm?</button>
+        <span className="absolute top-0 right-0 p-4"></span>
+      </div>
+    </div>
+  );
+};
+
+export default Confirm;

--- a/src/components/Confirm/index.tsx
+++ b/src/components/Confirm/index.tsx
@@ -1,0 +1,1 @@
+export { default as Confirm } from "./Confirm";

--- a/src/components/Timer/Panel.tsx
+++ b/src/components/Timer/Panel.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from "react";
+import { ChangeEvent, Dispatch, SetStateAction } from "react";
 import {
   average,
   averageCurved,
@@ -21,31 +21,48 @@ interface PanelProps {
   inspectionRunning: boolean;
   setSolveSessionId: Dispatch<SetStateAction<null>>;
   solveTimes: Solve[];
-};
+}
 
 const SESSION_LENGTH = 12;
 
 const Panel = (props: PanelProps) => {
-  const { classicModeEnabled, dispatch, inspectionRunning, setSolveSessionId, solveTimes } = props;
+  const {
+    classicModeEnabled,
+    dispatch,
+    inspectionRunning,
+    setSolveSessionId,
+    solveTimes,
+  } = props;
   const { data: session } = useSession();
-  const [createSolveSession, { }] = useMutation(CREATE_SOLVE_SESSION);
-  const times = solveTimes.map(s => s.time);
+  const [createSolveSession, {}] = useMutation(CREATE_SOLVE_SESSION);
+  const times = solveTimes.map((s) => s.time);
 
   const runningTimes = () => {
     if (classicModeEnabled) {
-      return <p>Session Average: {humanReadableTime(averageCurved(times, SESSION_LENGTH))}</p>
+      return (
+        <p>
+          Session Average:{" "}
+          {humanReadableTime(averageCurved(times, SESSION_LENGTH))}
+        </p>
+      );
     } else {
-      return <>
-        <p>Ao5: {humanReadableTime(averageOfSize(times, 5))}</p>
-        <p>Ao10: {humanReadableTime(averageOfSize(times, 10))}</p>
-      </>
+      return (
+        <>
+          <p>Ao5: {humanReadableTime(averageOfSize(times, 5))}</p>
+          <p>Ao10: {humanReadableTime(averageOfSize(times, 10))}</p>
+        </>
+      );
     }
   };
 
-  const toggleClassicMode = async () => {
+  const toggleClassicMode = async (event: ChangeEvent<HTMLInputElement>) => {
+    event.target.blur();
+
     if (!classicModeEnabled && session) {
       const userId = session.user.id;
-      const response = await createSolveSession({ variables: { userId, size: 12 } });
+      const response = await createSolveSession({
+        variables: { userId, size: 12 },
+      });
       setSolveSessionId(response.data?.createSolveSession.id);
     }
 
@@ -71,8 +88,14 @@ const Panel = (props: PanelProps) => {
           inspectionRunning={inspectionRunning}
         />
         <div>
-          <label htmlFor="classicMode" className="mr-2">Classic mode:</label>
-          <input id="classicMode" type="checkbox" onChange={toggleClassicMode} />
+          <label htmlFor="classicMode" className="mr-2">
+            Classic mode:
+          </label>
+          <input
+            id="classicMode"
+            type="checkbox"
+            onChange={toggleClassicMode}
+          />
         </div>
       </div>
     </div>

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -12,6 +12,10 @@ import { SAVE_SOLVE } from "../../graphql/mutations";
 
 const AUDIO_DING = "/assets/audio/ding.mp3";
 
+interface OkOptions {
+  penalty: number;
+}
+
 const Timer = () => {
   const [state, dispatch] = useReducer(TimerReducer, initialState);
   const [buttonLocked, setButtonLocked] = useState(false);
@@ -48,6 +52,7 @@ const Timer = () => {
   const handleKeyup = useCallback(
     async (e: KeyboardEvent | React.MouseEvent) => {
       if (e.type === "keyup" && (e as KeyboardEvent).key !== " ") return;
+      if (buttonLocked && confirmActive) recordSolve();
       if (buttonLocked) return;
       e.preventDefault();
 
@@ -57,7 +62,7 @@ const Timer = () => {
 
       if (!state.running) return;
 
-      setConfirmActive(true);
+      toggleConfirmModal();
     },
     [
       saveSolve,
@@ -72,7 +77,7 @@ const Timer = () => {
     ]
   );
 
-  const recordSolve = async (options = { penalty: 0 }) => {
+  const recordSolve = async (options: OkOptions = { penalty: 0 }) => {
     const { penalty } = options;
     let solveId;
 
@@ -92,7 +97,13 @@ const Timer = () => {
       solveId = response.data?.createSolve.id;
     }
 
+    toggleConfirmModal();
     dispatch({ type: TimerActionKind.ADD_TIME, solveId });
+  };
+
+  const toggleConfirmModal = () => {
+    setConfirmActive(!confirmActive);
+    setButtonLocked(!buttonLocked);
   };
 
   useEffect(() => {
@@ -179,7 +190,7 @@ const Timer = () => {
           <Confirm
             active={confirmActive}
             ok={recordSolve}
-            setActive={setConfirmActive}
+            toggle={toggleConfirmModal}
           />
           <Panel
             classicModeEnabled={state.classicModeEnabled}

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -72,8 +72,11 @@ const Timer = () => {
     ]
   );
 
-  const recordSolve = async () => {
+  const recordSolve = async (options = { penalty: 0 }) => {
+    const { penalty } = options;
     let solveId;
+
+    if (penalty) dispatch({ type: TimerActionKind.PENALTY, value: penalty });
 
     if (session) {
       const response = await saveSolve({
@@ -89,7 +92,6 @@ const Timer = () => {
       solveId = response.data?.createSolve.id;
     }
 
-    setConfirmActive(false);
     dispatch({ type: TimerActionKind.ADD_TIME, solveId });
   };
 
@@ -174,7 +176,11 @@ const Timer = () => {
           {state.classicModeEnabled && (
             <ClassicModeTimes solveTimes={state.solveTimes} />
           )}
-          <Confirm active={confirmActive} callback={recordSolve} />
+          <Confirm
+            active={confirmActive}
+            ok={recordSolve}
+            setActive={setConfirmActive}
+          />
           <Panel
             classicModeEnabled={state.classicModeEnabled}
             dispatch={dispatch}

--- a/src/reducers/timer.reducer.ts
+++ b/src/reducers/timer.reducer.ts
@@ -29,8 +29,11 @@ const TimerReducer = (state: TimerState, action: TimerAction) => {
     case TimerActionKind.ADD_TIME:
       return {
         ...state,
-        solveTimes: [...state.solveTimes, { time: state.time, id: action.solveId }],
-      }
+        solveTimes: [
+          ...state.solveTimes,
+          { time: state.time, id: action.solveId },
+        ],
+      };
     case TimerActionKind.REMOVE_TIME:
       return {
         ...state,
@@ -40,6 +43,12 @@ const TimerReducer = (state: TimerState, action: TimerAction) => {
       return { ...state, time: state.time + 60 };
     case TimerActionKind.COUNTDOWN:
       return { ...state, countdown: action.value };
+    case TimerActionKind.PENALTY:
+      return {
+        ...state,
+        time: state.time + action.value,
+        penalty: action.value,
+      };
     case TimerActionKind.PUZZLE_TYPE:
       return {
         ...state,

--- a/src/types/timer.ts
+++ b/src/types/timer.ts
@@ -4,6 +4,7 @@ export enum TimerActionKind {
   INITIALIZE = "INITIALIZE",
   INSPECTION_TIME = "INSPECTION_TIME",
   PUZZLE_TYPE = "PUZZLE_TYPE",
+  PENALTY = "PENALTY",
   READY = "READY",
   REMOVE_TIME = "REMOVE_TIME",
   TICK_UP = "TICK_UP",
@@ -32,16 +33,17 @@ export interface TimerState {
 
 export type TimerAction =
   | {
-    type:
-    | TimerActionKind.INITIALIZE
-    | TimerActionKind.TOGGLE_CLASSIC_MODE
-    | TimerActionKind.TOGGLE_INSPECTION
-    | TimerActionKind.TOGGLE_RUNNING
-    | TimerActionKind.READY
-    | TimerActionKind.TICK_UP;
-  }
+      type:
+        | TimerActionKind.INITIALIZE
+        | TimerActionKind.TOGGLE_CLASSIC_MODE
+        | TimerActionKind.TOGGLE_INSPECTION
+        | TimerActionKind.TOGGLE_RUNNING
+        | TimerActionKind.READY
+        | TimerActionKind.TICK_UP;
+    }
   | { type: TimerActionKind.ADD_TIME; solveId: string }
-  | { type: TimerActionKind.REMOVE_TIME; index: number }
-  | { type: TimerActionKind.PUZZLE_TYPE; puzzle: string }
+  | { type: TimerActionKind.COUNTDOWN; value: number }
   | { type: TimerActionKind.INSPECTION_TIME; inspectionTime: number }
-  | { type: TimerActionKind.COUNTDOWN; value: number };
+  | { type: TimerActionKind.PENALTY; value: number }
+  | { type: TimerActionKind.PUZZLE_TYPE; puzzle: string }
+  | { type: TimerActionKind.REMOVE_TIME; index: number };


### PR DESCRIPTION
Add confirmation modal with the ability to confirm, reject or add +2 penalty.
Adds all the reducer logic around adding penalties.

We also allow control of the modal via the spacebar to replicate behavior of the original version of the app so this required:
  - fixing button spam bug toggling classic mode by blurring that input
  - modifying the onKeyUp event logic

We'd like to also display when a penalty has occurred in the output panel(s) but this requires updating the datatype from a simple array of times to objects that are aware of the solves' state such as incurring a penalty.
